### PR TITLE
[0.2/n] - Split out the predict image endpoint to make room for video

### DIFF
--- a/src/dragoneye/classification.py
+++ b/src/dragoneye/classification.py
@@ -41,7 +41,7 @@ class Classification:
     def __init__(self, client: "Dragoneye"):
         self._client = client
 
-    def predict(
+    def predict_image(
         self, image: Image, model_name: str
     ) -> ClassificationPredictImageResponse:
         url = f"{BASE_API_URL}/predict"


### PR DESCRIPTION
Going to have 2 separate API endpoints, one for video and one for images