### PR TITLE
[5/n] - Return the prediction task uuid alongside predictions

### DIFF
--- a/src/dragoneye/classification.py
+++ b/src/dragoneye/classification.py
@@ -161,6 +161,9 @@ class Classification:
                 f"Error getting prediction task results: {error}"
             )
 
+        # Add the prediction task uuid to the response before returning
+        payload["prediction_task_uuid"] = prediction_task_uuid
+
         match prediction_type:
             case "image":
                 return ClassificationPredictImageResponse.model_validate(payload)

--- a/src/dragoneye/models.py
+++ b/src/dragoneye/models.py
@@ -33,6 +33,7 @@ class ClassificationObjectPrediction(BaseModel):
 
 class ClassificationPredictImageResponse(BaseModel):
     predictions: Sequence[ClassificationObjectPrediction]
+    prediction_task_uuid: PredictionTaskUUID
 
 
 class ClassificationVideoObjectPrediction(ClassificationObjectPrediction):
@@ -44,3 +45,4 @@ class ClassificationVideoObjectPrediction(ClassificationObjectPrediction):
 class ClassificationPredictVideoResponse(BaseModel):
     timestamp_to_predictions: dict[float, Sequence[ClassificationVideoObjectPrediction]]
     frames_per_second: int
+    prediction_task_uuid: PredictionTaskUUID


### PR DESCRIPTION
Return the prediction task uuid to the user. It should be better than burying it because then worst case they could give it to us as a reference, and they can fetch results multiple times if needed.